### PR TITLE
feat: import names with associated type

### DIFF
--- a/src/main/java/com/neo4j/data/importer/extractors/DefaultPersonExtractor.java
+++ b/src/main/java/com/neo4j/data/importer/extractors/DefaultPersonExtractor.java
@@ -2,6 +2,7 @@ package com.neo4j.data.importer.extractors;
 
 import com.joestelmach.natty.Parser;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -48,6 +49,38 @@ class DefaultPersonExtractor implements PersonExtractor {
     @Override
     public Map<String, Object> facts(Person person) {
         return EventFacts.extractFlat(person.getEventsFacts(), dateParser);
+    }
+
+    @Override
+    public Map<String, Object> typedNames(Person person) {
+        var names = person.getNames();
+        if (names.isEmpty()) {
+            return Map.of();
+        }
+        Map<String, Object> result = new HashMap<>();
+
+        // First 'name' entry is the preferred name
+        var preferred = names.get(0);
+        putIfPresent(result, "preferred_first_name", preferred.getGiven());
+        putIfPresent(result, "preferred_last_name", preferred.getSurname());
+
+        for (Name name : names) {
+            var type = name.getType();
+            if (type == null || type.isBlank()) {
+                continue;
+            }
+            var normalizedType = type.trim().toLowerCase(Locale.ROOT);
+            putIfPresent(result, normalizedType + "_first_name", name.getGiven());
+            putIfPresent(result, normalizedType + "_last_name", name.getSurname());
+        }
+
+        return result;
+    }
+
+    private static void putIfPresent(Map<String, Object> map, String key, String value) {
+        if (value != null && !value.isBlank()) {
+            map.put(key, PersonNames.unquote(value.trim()));
+        }
     }
 
     private static List<String> extractNames(Person person, Function<Name, String> nameFn) {

--- a/src/main/java/com/neo4j/data/importer/extractors/HeredisPersonExtractor.java
+++ b/src/main/java/com/neo4j/data/importer/extractors/HeredisPersonExtractor.java
@@ -40,6 +40,11 @@ class HeredisPersonExtractor implements PersonExtractor {
     }
 
     @Override
+    public Map<String, Object> typedNames(Person person) {
+        return delegate.typedNames(person);
+    }
+
+    @Override
     public Optional<String> preferredFirstName(Person person) {
         var preferredNames = PersonNames.extract(person, Name::getGiven)
                 .filter(PersonNames::isQuoted)

--- a/src/main/java/com/neo4j/data/importer/extractors/PersonExtractor.java
+++ b/src/main/java/com/neo4j/data/importer/extractors/PersonExtractor.java
@@ -24,6 +24,10 @@ interface PersonExtractor extends AttributeExtractor<Person> {
         return Optional.empty();
     }
 
+    default Map<String, Object> typedNames(Person person) {
+        return Map.of();
+    }
+
     default String query() {
         return "CREATE (i:Person) SET i = $attributes";
     }
@@ -33,8 +37,9 @@ interface PersonExtractor extends AttributeExtractor<Person> {
         attributes.put("id", id(person));
         attributes.put("first_names", firstNames(person));
         attributes.put("last_names", surnames(person));
+        attributes.putAll(typedNames(person));
         gender(person).ifPresent(gender -> attributes.put("gender", gender));
-        preferredFirstName(person).ifPresent(gender -> attributes.put("preferred_first_name", gender));
+        preferredFirstName(person).ifPresent(p -> attributes.put("preferred_first_name", p));
         return attributes;
     }
 

--- a/src/test/java/com/neo4j/data/importer/GedcomImporterTest.java
+++ b/src/test/java/com/neo4j/data/importer/GedcomImporterTest.java
@@ -285,7 +285,28 @@ class GedcomImporterTest {
                             "raw_date", "23 OCT 2017",
                             "location", "Strasbourg,67000,Bas Rhin,Alsace,FRANCE,"));
         }
-        ;
+    }
+
+    @Test
+    void parses_alternate_names() {
+        try (Driver driver = GraphDatabase.driver(neo4j.boltURI())) {
+            loadGedcom(driver, "AlternateNames.ged");
+
+            var person = driver
+                    .executableQuery("MATCH (p:Person) RETURN p")
+                    .execute(Collectors.toList())
+                    .stream()
+                    .map(record -> record.get("p").asNode())
+                    .findFirst()
+                    .orElseThrow();
+
+            assertThat(person.get("preferred_first_name").asString()).isEqualTo("Jane");
+            assertThat(person.get("preferred_last_name").asString()).isEqualTo("Smith");
+            assertThat(person.get("birth_first_name").asString()).isEqualTo("Jane");
+            assertThat(person.get("birth_last_name").asString()).isEqualTo("Jones");
+            assertThat(person.get("married_first_name").asString()).isEqualTo("Jane");
+            assertThat(person.get("married_last_name").asString()).isEqualTo("Smith");
+        }
     }
 
     private static FamilyRelation familyRel(Person person1, String relType, Person person2) {

--- a/src/test/java/com/neo4j/data/importer/GedcomImporterTest.java
+++ b/src/test/java/com/neo4j/data/importer/GedcomImporterTest.java
@@ -292,10 +292,7 @@ class GedcomImporterTest {
         try (Driver driver = GraphDatabase.driver(neo4j.boltURI())) {
             loadGedcom(driver, "AlternateNames.ged");
 
-            var person = driver
-                    .executableQuery("MATCH (p:Person) RETURN p")
-                    .execute(Collectors.toList())
-                    .stream()
+            var person = driver.executableQuery("MATCH (p:Person) RETURN p").execute(Collectors.toList()).stream()
                     .map(record -> record.get("p").asNode())
                     .findFirst()
                     .orElseThrow();

--- a/src/test/resources/ged-files/AlternateNames.ged
+++ b/src/test/resources/ged-files/AlternateNames.ged
@@ -1,0 +1,14 @@
+0 HEAD
+1 SOUR Gramps
+2 VERS AIO64-5.2.3-r1-aa03f5a
+2 NAME Gramps
+0 @I0001@ INDI
+1 NAME Jane /Smith/
+2 TYPE married
+2 GIVN Jane
+2 SURN Smith
+1 NAME Jane /Jones/
+2 TYPE birth
+2 GIVN Jane
+2 SURN Jones
+1 SEX F


### PR DESCRIPTION
## Issue

Currently the import of names is a concatenated list of all first names and last names. In the Gedcom standard for names there is an given type. We should import these names with the types to make it clear what the names is.

## Fix
Iterate through all names an prefix the type to the name.
As far as i can tell when you set a preferred name in software such as Gramps it corresponds to the first name provided for an individual. I'm not 100% sure on this but have seen a few discussions around it i.e. https://github.com/fisharebest/gedcom-name